### PR TITLE
Allow to use source date for man page generation

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,5 +1,5 @@
 .0.1:
-	@sed -e "s/!VERSION!/@JACK_RELEASE@/g" -e "s/!DATE!/`date '+%B %Y'`/g" < $*.0 > $@
+	@[ -z "$$SOURCE_DATE_EPOCH" ] || d=--date=@$$SOURCE_DATE_EPOCH ; sed -e "s/!VERSION!/@JACK_RELEASE@/g" -e "s/!DATE!/`date $$d '+%B %Y'`/g" < $*.0 > $@
 	@echo Built $*.1 from template
 
 manpages = $(patsubst %.0,%.1,$(wildcard *.0))


### PR DESCRIPTION
this enables making reproducible builds of this package

see also https://reproducible-builds.org/specs/source-date-epoch/
